### PR TITLE
fix: inverse_transform fails with single mode and normalized pcs

### DIFF
--- a/tests/models/test_opa.py
+++ b/tests/models/test_opa.py
@@ -278,9 +278,10 @@ def test_inverse_transform(dim, mock_data_array, opa_model):
 
     # fit the EOF model
     opa_model.fit(mock_data_array, dim=dim)
+    scores = opa_model.scores()
 
     with pytest.raises(NotImplementedError):
-        opa_model.inverse_transform(1)
+        opa_model.inverse_transform(scores)
 
     # # Test with scalar
     # mode = 1

--- a/xeofs/models/eof.py
+++ b/xeofs/models/eof.py
@@ -128,12 +128,12 @@ class EOF(_BaseModel):
 
         return projections
 
-    def _inverse_transform_algorithm(self, scores: DataObject) -> DataArray:
+    def _inverse_transform_algorithm(self, scores: DataArray) -> DataArray:
         """Reconstruct the original data from transformed data.
 
         Parameters
         ----------
-        scores: DataObject
+        scores: DataArray
             Transformed data to be reconstructed. This could be a subset
             of the `scores` data of a fitted model, or unseen data. Must
             have a 'mode' dimension.
@@ -147,7 +147,7 @@ class EOF(_BaseModel):
         # Reconstruct the data
         comps = self.data["components"].sel(mode=scores.mode)
 
-        reconstructed_data = xr.dot(comps.conj(), scores)
+        reconstructed_data = xr.dot(comps.conj(), scores, dims="mode")
         reconstructed_data.name = "reconstructed_data"
 
         # Enforce real output


### PR DESCRIPTION
Reconstructing the original data via 'inverse_transform' fails when a single mode is used with normalized PCs. Explicilty select the number of modes of the L2 norms to avoid incorrect broadcasting.

resolves #149