### PR TITLE
refactor: add `PCAPreprocessor` class

### DIFF
--- a/tests/preprocessing/test_pca_preprocessor_dataarray.py
+++ b/tests/preprocessing/test_pca_preprocessor_dataarray.py
@@ -1,0 +1,181 @@
+import pytest
+import numpy as np
+
+from xeofs.preprocessing.preprocessor import Preprocessor
+from ..conftest import generate_synthetic_dataarray
+from ..utilities import (
+    get_dims_from_data,
+    data_is_dask,
+    data_has_multiindex,
+    assert_expected_dims,
+    assert_expected_coords,
+)
+
+# =============================================================================
+# GENERALLY VALID TEST CASES
+# =============================================================================
+N_SAMPLE_DIMS = [1, 2]
+N_FEATURE_DIMS = [1, 2]
+INDEX_POLICY = ["index", "multiindex"]
+NAN_POLICY = ["no_nan", "fulldim"]
+DASK_POLICY = ["no_dask", "dask"]
+SEED = [0]
+
+TEST_DATA_PARAMS = [
+    (ns, nf, index, nan, dask)
+    for ns in N_SAMPLE_DIMS
+    for nf in N_FEATURE_DIMS
+    for index in INDEX_POLICY
+    for nan in NAN_POLICY
+    for dask in DASK_POLICY
+]
+
+SAMPLE_DIM_NAMES = ["sample", "sample_alternative"]
+FEATURE_DIM_NAMES = ["feature", "feature_alternative"]
+
+VALID_TEST_CASES = [
+    (sample_name, feature_name, data_params)
+    for sample_name in SAMPLE_DIM_NAMES
+    for feature_name in FEATURE_DIM_NAMES
+    for data_params in TEST_DATA_PARAMS
+]
+
+
+# TESTS
+# =============================================================================
+@pytest.mark.parametrize(
+    "with_std, with_coslat, with_weights",
+    [
+        (True, True, True),
+        (True, True, False),
+        (True, False, True),
+        (True, False, False),
+        (False, True, True),
+        (False, True, False),
+        (False, False, True),
+        (False, False, False),
+    ],
+)
+def test_fit_transform_scalings(with_std, with_coslat, with_weights, mock_data_array):
+    """fit method should not be implemented."""
+    prep = Preprocessor(with_std=with_std, with_coslat=with_coslat)
+
+    weights = None
+    if with_weights:
+        weights = mock_data_array.mean("time").copy()
+        weights[:] = 0.5
+
+    data_trans = prep.fit_transform(
+        mock_data_array,
+        weights=weights,
+        sample_dims=("time",),
+    )
+
+    assert hasattr(prep, "scaler")
+    assert hasattr(prep, "preconverter")
+    assert hasattr(prep, "stacker")
+    assert hasattr(prep, "postconverter")
+    assert hasattr(prep, "sanitizer")
+
+    # Transformed data is centered
+    assert np.isclose(data_trans.mean("sample"), 0).all()
+    # Transformed data is standardized
+    if with_std and not with_coslat:
+        if with_weights:
+            assert np.isclose(data_trans.std("sample"), 0.5).all()
+        else:
+            assert np.isclose(data_trans.std("sample"), 1).all()
+
+
+@pytest.mark.parametrize(
+    "index_policy, nan_policy, dask_policy",
+    [
+        ("index", "no_nan", "no_dask"),
+        ("multiindex", "no_nan", "dask"),
+        ("index", "fulldim", "no_dask"),
+        ("multiindex", "fulldim", "dask"),
+    ],
+)
+def test_fit_transform_same_dim_names(index_policy, nan_policy, dask_policy):
+    data = generate_synthetic_dataarray(1, 1, index_policy, nan_policy, dask_policy)
+    all_dims, sample_dims, feature_dims = get_dims_from_data(data)
+
+    prep = Preprocessor(sample_name="sample0", feature_name="feature0")
+    transformed = prep.fit_transform(data, sample_dims)
+    reconstructed = prep.inverse_transform_data(transformed)
+
+    data_is_dask_before = data_is_dask(data)
+    data_is_dask_interm = data_is_dask(transformed)
+    data_is_dask_after = data_is_dask(reconstructed)
+
+    assert set(transformed.dims) == set(("sample0", "feature0"))
+    assert set(reconstructed.dims) == set(("sample0", "feature0"))
+    assert not data_has_multiindex(transformed)
+    assert transformed.notnull().all()
+    assert data_is_dask_before == data_is_dask_interm
+    assert data_is_dask_before == data_is_dask_after
+
+
+@pytest.mark.parametrize(
+    "sample_name, feature_name, data_params",
+    VALID_TEST_CASES,
+)
+def test_fit_transform(sample_name, feature_name, data_params):
+    data = generate_synthetic_dataarray(*data_params)
+    all_dims, sample_dims, feature_dims = get_dims_from_data(data)
+
+    prep = Preprocessor(sample_name=sample_name, feature_name=feature_name)
+    transformed = prep.fit_transform(data, sample_dims)
+
+    data_is_dask_before = data_is_dask(data)
+    data_is_dask_after = data_is_dask(transformed)
+
+    assert transformed.dims == (sample_name, feature_name)
+    assert not data_has_multiindex(transformed)
+    assert transformed.notnull().all()
+    assert data_is_dask_before == data_is_dask_after
+
+
+@pytest.mark.parametrize(
+    "sample_name, feature_name, data_params",
+    VALID_TEST_CASES,
+)
+def test_inverse_transform(sample_name, feature_name, data_params):
+    data = generate_synthetic_dataarray(*data_params)
+    all_dims, sample_dims, feature_dims = get_dims_from_data(data)
+
+    prep = Preprocessor(sample_name=sample_name, feature_name=feature_name)
+    transformed = prep.fit_transform(data, sample_dims)
+    components = transformed.rename({sample_name: "mode"})
+    scores = transformed.rename({feature_name: "mode"})
+
+    reconstructed = prep.inverse_transform_data(transformed)
+    components = prep.inverse_transform_components(components)
+    scores = prep.inverse_transform_scores(scores)
+
+    # Reconstructed data has the same dimensions as the original data
+    assert_expected_dims(data, reconstructed, policy="all")
+    assert_expected_dims(data, components, policy="feature")
+    assert_expected_dims(data, scores, policy="sample")
+
+    # Reconstructed data has the same coordinates as the original data
+    assert_expected_coords(data, reconstructed, policy="all")
+    assert_expected_coords(data, components, policy="feature")
+    assert_expected_coords(data, scores, policy="sample")
+
+    # Reconstructed data and original data have NaNs in the same FEATURES
+    # Note: NaNs in the same place is not guaranteed, since isolated NaNs will be propagated
+    # to all samples in the same feature
+    features_with_nans_before = data.isnull().any(sample_dims)
+    features_with_nans_after = reconstructed.isnull().any(sample_dims)
+    assert features_with_nans_before.equals(features_with_nans_after)
+
+    # Reconstructed data has MultiIndex if and only if original data has MultiIndex
+    data_has_multiindex_before = data_has_multiindex(data)
+    data_has_multiindex_after = data_has_multiindex(reconstructed)
+    assert data_has_multiindex_before == data_has_multiindex_after
+
+    # Reconstructed data is dask if and only if original data is dask
+    data_is_dask_before = data_is_dask(data)
+    data_is_dask_after = data_is_dask(reconstructed)
+    assert data_is_dask_before == data_is_dask_after

--- a/xeofs/preprocessing/pca_preprocessor.py
+++ b/xeofs/preprocessing/pca_preprocessor.py
@@ -1,0 +1,155 @@
+from typing import List, Optional, Tuple
+
+import numpy as np
+from typing_extensions import Self
+
+from ..utils.data_types import (
+    Data,
+    Dims,
+    DimsList,
+)
+from .concatenator import Concatenator
+from .dimension_renamer import DimensionRenamer
+from .multi_index_converter import MultiIndexConverter
+from .preprocessor import Preprocessor
+from .sanitizer import Sanitizer
+from .scaler import Scaler
+from .stacker import Stacker
+from .whitener import Whitener
+
+
+def extract_new_dim_names(X: List[DimensionRenamer]) -> Tuple[Dims, DimsList]:
+    """Extract the new dimension names from a list of DimensionRenamer objects.
+
+    Parameters
+    ----------
+    X : list of DimensionRenamer
+        List of DimensionRenamer objects.
+
+    Returns
+    -------
+    Dims
+        Sample dimensions
+    DimsList
+        Feature dimenions
+
+    """
+    new_sample_dims = []
+    new_feature_dims: DimsList = []
+    for x in X:
+        new_sample_dims.append(x.sample_dims_after)
+        new_feature_dims.append(x.feature_dims_after)
+    new_sample_dims: Dims = tuple(np.unique(np.asarray(new_sample_dims)).tolist())
+    return new_sample_dims, new_feature_dims
+
+
+class PCAPreprocessor(Preprocessor):
+    """Preprocess xarray objects and transform into (whitened) PC space.
+
+    PCA-Preprocesser includes steps from Preprocessor class:
+        (i) Feature-wise scaling (e.g. removing mean, dividing by standard deviation, applying (latitude) weights
+        (ii) Renaming dimensions (to avoid conflicts with sample and feature dimensions)
+        (iii) Converting MultiIndexes to regular Indexes (MultiIndexes cannot be stacked)
+        (iv) Stacking the data into 2D DataArray
+        (v) Converting MultiIndexes introduced by stacking into regular Indexes
+        (vi) Removing NaNs
+        (vii) Concatenating the 2D DataArrays into one 2D DataArray
+        (viii) Transform into whitened PC space
+
+
+    Parameters
+    ----------
+    n_modes : int | float
+        If int, specifies the number of modes to retain. If float, specifies the fraction of variance in the whitened data that should be explained by the retained modes.
+    alpha : float, default=0.0
+        Degree of whitening. If 0, the data is completely whitened. If 1, the data is not whitened.
+    init_rank_reduction : float, default=0.3
+        Fraction of the initial rank to reduce the data to before applying PCA.
+    sample_name : str, default="sample"
+        Name of the sample dimension.
+    feature_name : str, default="feature"
+        Name of the feature dimension.
+    with_center : bool, default=True
+        If True, the data is centered by subtracting the mean.
+    with_std : bool, default=True
+        If True, the data is divided by the standard deviation.
+    with_coslat : bool, default=False
+        If True, the data is multiplied by the square root of cosine of latitude weights.
+    with_weights : bool, default=False
+        If True, the data is multiplied by additional user-defined weights.
+    return_list : bool, default=True
+        If True, inverse_transform methods returns always a list of DataArray(s).
+        If False, the output is returned as a single DataArray if possible.
+    check_nans : bool, default=True
+        If True, remove full-dimensional NaN features from the data, check to ensure
+        that NaN features match the original fit data during transform, and check
+        for isolated NaNs. Note: this forces eager computation of dask arrays.
+        If False, skip all NaN checks. In this case, NaNs should be explicitly removed
+        or filled prior to fitting, or SVD will fail.
+
+    """
+
+    def __init__(
+        self,
+        n_modes: int | float,
+        alpha: float = 1.0,
+        init_rank_reduction: float = 0.3,
+        sample_name: str = "sample",
+        feature_name: str = "feature",
+        with_center: bool = True,
+        with_std: bool = False,
+        with_coslat: bool = False,
+        return_list: bool = True,
+        check_nans: bool = True,
+        compute: bool = True,
+    ):
+        super().__init__(
+            sample_name=sample_name,
+            feature_name=feature_name,
+            with_center=with_center,
+            with_std=with_std,
+            with_coslat=with_coslat,
+            return_list=return_list,
+            check_nans=check_nans,
+            compute=compute,
+        )
+
+        # Set parameters
+        self.n_modes = n_modes
+        self.alpha = alpha
+        self.init_rank_reduction = init_rank_reduction
+
+        # 8 | PCA-Whitener
+        self.whitener = Whitener(
+            n_modes=self.n_modes,
+            init_rank_reduction=self.init_rank_reduction,
+            alpha=self.alpha,
+            sample_name=self.sample_name,
+            feature_name=self.feature_name,
+        )
+
+    def transformer_types(self):
+        """Ordered list of transformer operations."""
+        return dict(
+            scaler=Scaler,
+            renamer=DimensionRenamer,
+            preconverter=MultiIndexConverter,
+            stacker=Stacker,
+            postconverter=MultiIndexConverter,
+            sanitizer=Sanitizer,
+            concatenator=Concatenator,
+            whitener=Whitener,
+        )
+
+    def _fit_algorithm(
+        self,
+        X: List[Data] | Data,
+        sample_dims: Dims,
+        weights: Optional[List[Data] | Data] = None,
+    ) -> Tuple[Self, Data]:
+        _, X = super()._fit_algorithm(X, sample_dims, weights)
+
+        # 8 | PCA-Whitening
+        X = self.whitener.fit_transform(X)  # type: ignore
+
+        return self, X

--- a/xeofs/preprocessing/preprocessor.py
+++ b/xeofs/preprocessing/preprocessor.py
@@ -1,35 +1,34 @@
-from typing import Optional, List, Tuple, Dict
-from typing_extensions import Self
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
+from typing_extensions import Self
+
+from ..utils.data_types import (
+    Data,
+    DataArray,
+    Dims,
+    DimsList,
+)
+from ..utils.xarray_utils import (
+    _check_parameter_number,
+    convert_to_list,
+    get_dims,
+    process_parameter,
+    unwrap_singleton_list,
+)
+from .concatenator import Concatenator
+from .dimension_renamer import DimensionRenamer
+from .list_processor import GenericListTransformer
+from .multi_index_converter import MultiIndexConverter
+from .sanitizer import Sanitizer
+from .scaler import Scaler
+from .stacker import Stacker
+from .transformer import Transformer
 
 try:
     from xarray.core.datatree import DataTree
 except ImportError:
     from datatree import DataTree
-
-
-from .list_processor import GenericListTransformer
-from .dimension_renamer import DimensionRenamer
-from .scaler import Scaler
-from .stacker import Stacker
-from .multi_index_converter import MultiIndexConverter
-from .sanitizer import Sanitizer
-from .concatenator import Concatenator
-from .transformer import Transformer
-from ..utils.xarray_utils import (
-    get_dims,
-    unwrap_singleton_list,
-    process_parameter,
-    _check_parameter_number,
-    convert_to_list,
-)
-from ..utils.data_types import (
-    DataArray,
-    Data,
-    Dims,
-    DimsList,
-)
 
 
 def extract_new_dim_names(X: List[DimensionRenamer]) -> Tuple[Dims, DimsList]:


### PR DESCRIPTION
This PR introduces a `PCAPreprocessor` class for transforming input data into a whitened, rank-reduced PCA space. It’s useful for cross models, enabling dimensionality reduction before extracting common patterns. This class is a key component of Continuum Power CCA (see #178).