### PR TITLE
fix: add deprecation warning for `Complex` model classes

### DIFF
--- a/docs/api_reference/multi_set_analysis.rst
+++ b/docs/api_reference/multi_set_analysis.rst
@@ -9,7 +9,7 @@ Methods that investigate relationships or patterns between variables across two 
    :recursive:
 
    xeofs.models.MCA
-   xeofs.models.ComplexMCA
+   xeofs.models.HilbertMCA
    xeofs.models.CCA
 
 ------------------------------
@@ -22,4 +22,4 @@ Sparse Solutions via Rotation
    :recursive:
 
    xeofs.models.MCARotator
-   xeofs.models.ComplexMCARotator
+   xeofs.models.HilbertMCARotator

--- a/docs/api_reference/single_set_analysis.rst
+++ b/docs/api_reference/single_set_analysis.rst
@@ -10,7 +10,7 @@ Methods that examine relationships among variables within a single dataset, or w
     :recursive:
 
     xeofs.models.EOF
-    xeofs.models.ComplexEOF
+    xeofs.models.HilbertEOF
     xeofs.models.ExtendedEOF
     xeofs.models.OPA
     xeofs.models.GWPCA
@@ -27,4 +27,4 @@ Sparse Solutions via Rotation
     :recursive:
 
     xeofs.models.EOFRotator
-    xeofs.models.ComplexEOFRotator
+    xeofs.models.HilbertEOFRotator

--- a/examples/1single/plot_complex_eof.py
+++ b/examples/1single/plot_complex_eof.py
@@ -1,8 +1,8 @@
 """
-Complex/Hilbert EOF analysis
+Hilbert EOF analysis
 ============================================
 
-We demonstrate how to execute a Complex EOF (or Hilbert EOF) analysis [1]_ [2]_ [3]_.
+We demonstrate how to execute a Hilbert EOF analysis [1]_ [2]_ [3]_.
 This method extends traditional EOF analysis into the complex domain, allowing
 the EOF components to have real and imaginary parts. This capability can reveal
 oscillatory patterns in datasets, which are common in Earth observations.
@@ -20,8 +20,9 @@ Let's start by importing the necessary packages and loading the data:
 """
 
 # %%
-import xeofs as xe
 import xarray as xr
+
+import xeofs as xe
 
 xr.set_options(display_expand_attrs=False)
 
@@ -29,14 +30,14 @@ sst = xr.tutorial.open_dataset("ersstv5").sst
 sst
 
 # %%
-# We fit the Complex EOF model directly to the raw data, retaining the seasonal
+# We fit the Hilbert EOF model directly to the raw data, retaining the seasonal
 # cycle for study. The model initialization specifies the desired number of
 # modes. The ``use_coslat`` parameter is set to ``True`` to adjust for grid
-# convergence at the poles. While the ``ComplexEOF`` class offers padding options
+# convergence at the poles. While the ``HilbertEOF`` class offers padding options
 # to mitigate potential edge effects, we'll begin with no padding.
 
 kwargs = dict(n_modes=4, use_coslat=True, random_state=7)
-model = xe.models.ComplexEOF(padding="none", **kwargs)
+model = xe.models.HilbertEOF(padding="none", **kwargs)
 
 # %%
 # Now, we fit the model to the data and extract the explained variance.
@@ -76,14 +77,14 @@ scores.real.plot.line(x="time", col="mode", lw=1, ylim=(-0.1, 0.1))
 # However, mode three and four look unusual. While showing some similarity to
 # ENSO (e.g. in mode 3 peaks in 1982, 1998 and 2016), they exhibit a "running away"
 # behaviour towards the boundaries of the time series.
-# This a common issue in complex EOF analysis which is based on the Hilbert transform (a convolution)
+# This a common issue in Hilbert EOF analysis which is based on the Hilbert transform (a convolution)
 # that suffers from the absence of information at the time series boundaries. One way to mitigate this
 # is to artificially extend the time series also known as *padding*. In ``xeofs``, you can enable
 # such a padding by setting the ``padding`` parameter to ``"exp"`` which will extent the boundaries by an exponential
 # decaying function. The ``decay_factor`` parameter controls the decay rate of the exponential function measured in
 # multiples of the time series length. Let's see how the decay parameter impacts the results:
 
-model_ext = xe.models.ComplexEOF(padding="exp", decay_factor=0.01, **kwargs)
+model_ext = xe.models.HilbertEOF(padding="exp", decay_factor=0.01, **kwargs)
 model_ext.fit(sst, dim="time")
 scores_ext = model_ext.scores().sel(mode=slice(1, 4))
 

--- a/tests/models/test_complex_eof.py
+++ b/tests/models/test_complex_eof.py
@@ -1,8 +1,9 @@
-import numpy as np
-import pytest
 import warnings
 
-from xeofs.models import ComplexEOF
+import numpy as np
+import pytest
+
+from xeofs.models import HilbertEOF
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
@@ -17,9 +18,9 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
     ],
 )
 def test_fit(mock_data_array, dim):
-    """Test fitting a ComplexEOF model"""
+    """Test fitting a HilbertEOF model"""
     # Create a xarray DataArray with random data
-    ceof = ComplexEOF(n_modes=2)
+    ceof = HilbertEOF(n_modes=2)
     ceof.fit(mock_data_array, dim)
 
     # Check that the fit method has properly populated the attributes
@@ -36,8 +37,8 @@ def test_fit(mock_data_array, dim):
     ],
 )
 def test_components_amplitude(mock_data_array, dim):
-    """Test computation of components amplitude in ComplexEOF model"""
-    ceof = ComplexEOF(n_modes=2)
+    """Test computation of components amplitude in HilbertEOF model"""
+    ceof = HilbertEOF(n_modes=2)
     ceof.fit(mock_data_array, dim)
 
     comp_amp = ceof.components_amplitude()
@@ -54,8 +55,8 @@ def test_components_amplitude(mock_data_array, dim):
     ],
 )
 def test_components_phase(mock_data_array, dim):
-    """Test computation of components phase in ComplexEOF model"""
-    ceof = ComplexEOF(n_modes=2)
+    """Test computation of components phase in HilbertEOF model"""
+    ceof = HilbertEOF(n_modes=2)
     ceof.fit(mock_data_array, dim)
 
     comp_phase = ceof.components_phase()
@@ -72,8 +73,8 @@ def test_components_phase(mock_data_array, dim):
     ],
 )
 def test_scores_amplitude(mock_data_array, dim):
-    """Test computation of scores amplitude in ComplexEOF model"""
-    ceof = ComplexEOF(n_modes=2)
+    """Test computation of scores amplitude in HilbertEOF model"""
+    ceof = HilbertEOF(n_modes=2)
     ceof.fit(mock_data_array, dim)
 
     scores_amp = ceof.scores_amplitude()
@@ -90,8 +91,8 @@ def test_scores_amplitude(mock_data_array, dim):
     ],
 )
 def test_scores_phase(mock_data_array, dim):
-    """Test computation of scores phase in ComplexEOF model"""
-    ceof = ComplexEOF(n_modes=2)
+    """Test computation of scores phase in HilbertEOF model"""
+    ceof = HilbertEOF(n_modes=2)
     ceof.fit(mock_data_array, dim)
 
     scores_phase = ceof.scores_phase()
@@ -110,7 +111,7 @@ def test_scores_phase(mock_data_array, dim):
     ],
 )
 def test_compute(mock_dask_data_array, dim):
-    """Test computation of all attributes in ComplexEOF model"""
-    ceof = ComplexEOF(n_modes=2)
+    """Test computation of all attributes in HilbertEOF model"""
+    ceof = HilbertEOF(n_modes=2)
     with pytest.raises(NotImplementedError):
         ceof.fit(mock_dask_data_array, dim)

--- a/tests/models/test_complex_eof_rotator.py
+++ b/tests/models/test_complex_eof_rotator.py
@@ -1,27 +1,27 @@
 import pytest
 import xarray as xr
 
-from xeofs.models import ComplexEOF, ComplexEOFRotator
 from xeofs.data_container import DataContainer
+from xeofs.models import HilbertEOF, HilbertEOFRotator
 
 
 @pytest.fixture
 def ceof_model(mock_data_array, dim):
-    ceof = ComplexEOF(n_modes=5)
+    ceof = HilbertEOF(n_modes=5)
     ceof.fit(mock_data_array, dim)
     return ceof
 
 
 @pytest.fixture
 def ceof_model_delayed(mock_dask_data_array, dim):
-    ceof = ComplexEOF(n_modes=5)
+    ceof = HilbertEOF(n_modes=5)
     ceof.fit(mock_dask_data_array, dim)
     return ceof
 
 
 def test_init():
-    # Instantiate the ComplexEOFRotator class
-    ceof_rotator = ComplexEOFRotator(n_modes=3, power=2, max_iter=100, rtol=1e-6)
+    # Instantiate the HilbertEOFRotator class
+    ceof_rotator = HilbertEOFRotator(n_modes=3, power=2, max_iter=100, rtol=1e-6)
 
     assert ceof_rotator._params["n_modes"] == 3
     assert ceof_rotator._params["power"] == 2
@@ -38,7 +38,7 @@ def test_init():
     ],
 )
 def test_fit(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
 
     assert hasattr(
@@ -47,7 +47,7 @@ def test_fit(ceof_model):
     assert hasattr(
         ceof_rotator, "data"
     ), 'The attribute "data" should be populated after fitting.'
-    assert isinstance(ceof_rotator.model, ComplexEOF)
+    assert isinstance(ceof_rotator.model, HilbertEOF)
     assert isinstance(ceof_rotator.data, DataContainer)
 
 
@@ -60,7 +60,7 @@ def test_fit(ceof_model):
     ],
 )
 def test_transform_not_implemented(ceof_model, mock_data_array):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
 
     with pytest.raises(NotImplementedError):
@@ -76,7 +76,7 @@ def test_transform_not_implemented(ceof_model, mock_data_array):
     ],
 )
 def test_inverse_transform(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
     scores = ceof_rotator.data["scores"].isel(mode=1)
     Xrec = ceof_rotator.inverse_transform(scores)
@@ -93,7 +93,7 @@ def test_inverse_transform(ceof_model):
     ],
 )
 def test_components_amplitude(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
     comps_amp = ceof_rotator.components_amplitude()
 
@@ -109,7 +109,7 @@ def test_components_amplitude(ceof_model):
     ],
 )
 def test_components_phase(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
     comps_phase = ceof_rotator.components_phase()
 
@@ -125,7 +125,7 @@ def test_components_phase(ceof_model):
     ],
 )
 def test_scores_amplitude(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
     scores_amp = ceof_rotator.scores_amplitude()
 
@@ -141,7 +141,7 @@ def test_scores_amplitude(ceof_model):
     ],
 )
 def test_scores_phase(ceof_model):
-    ceof_rotator = ComplexEOFRotator(n_modes=3)
+    ceof_rotator = HilbertEOFRotator(n_modes=3)
     ceof_rotator.fit(ceof_model)
     scores_phase = ceof_rotator.scores_phase()
 

--- a/tests/models/test_complex_mca.py
+++ b/tests/models/test_complex_mca.py
@@ -1,16 +1,16 @@
 import pytest
 import xarray as xr
 
-from xeofs.models import ComplexMCA
+from xeofs.models import HilbertMCA
 
 
 @pytest.fixture
 def mca_model():
-    return ComplexMCA(n_modes=3)
+    return HilbertMCA(n_modes=3)
 
 
 def test_initialization():
-    mca = ComplexMCA(n_modes=1)
+    mca = HilbertMCA(n_modes=1)
     assert mca is not None
 
 
@@ -202,7 +202,7 @@ def test_scores_phase(mca_model, mock_data_array, dim):
     ],
 )
 def test_fit_empty_data(dim):
-    mca = ComplexMCA()
+    mca = HilbertMCA()
     with pytest.raises(ValueError):
         mca.fit(xr.DataArray(), xr.DataArray(), dim)
 
@@ -232,13 +232,13 @@ def test_transform_not_implemented(mca_model, mock_data_array, dim):
 
 
 def test_homogeneous_patterns_not_implemented():
-    mca = ComplexMCA()
+    mca = HilbertMCA()
     with pytest.raises(NotImplementedError):
         mca.homogeneous_patterns()
 
 
 def test_heterogeneous_patterns_not_implemented():
-    mca = ComplexMCA()
+    mca = HilbertMCA()
     with pytest.raises(NotImplementedError):
         mca.heterogeneous_patterns()
 

--- a/tests/models/test_complex_mca_rotator.py
+++ b/tests/models/test_complex_mca_rotator.py
@@ -1,27 +1,27 @@
-import pytest
 import numpy as np
+import pytest
 import xarray as xr
 
 # Import the classes from your modules
-from xeofs.models import ComplexMCA, ComplexMCARotator
+from xeofs.models import HilbertMCA, HilbertMCARotator
 
 
 @pytest.fixture
 def mca_model(mock_data_array, dim):
-    mca = ComplexMCA(n_modes=5)
+    mca = HilbertMCA(n_modes=5)
     mca.fit(mock_data_array, mock_data_array, dim)
     return mca
 
 
 @pytest.fixture
 def mca_model_delayed(mock_dask_data_array, dim):
-    mca = ComplexMCA(n_modes=5)
+    mca = HilbertMCA(n_modes=5)
     mca.fit(mock_dask_data_array, mock_dask_data_array, dim)
     return mca
 
 
 def test_init():
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     assert mca_rotator._params["n_modes"] == 2
     assert mca_rotator._params["power"] == 1
     assert mca_rotator._params["max_iter"] == 1000
@@ -38,7 +38,7 @@ def test_init():
     ],
 )
 def test_fit(mca_model):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
 
     assert hasattr(mca_rotator, "model")
@@ -54,7 +54,7 @@ def test_fit(mca_model):
     ],
 )
 def test_transform(mca_model, mock_data_array):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
 
     with pytest.raises(NotImplementedError):
@@ -70,7 +70,7 @@ def test_transform(mca_model, mock_data_array):
     ],
 )
 def test_inverse_transform(mca_model):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
 
     scores1 = mca_rotator.data["scores1"].sel(mode=slice(1, 3))
@@ -119,7 +119,7 @@ def test_squared_covariance_fraction(mca_model, mock_data_array, dim):
     ],
 )
 def test_singular_values(mca_model):
-    mca_rotator = ComplexMCARotator(n_modes=4)
+    mca_rotator = HilbertMCARotator(n_modes=4)
     mca_rotator.fit(mca_model)
     n_modes = mca_rotator.get_params()["n_modes"]
     svals = mca_rotator.singular_values()
@@ -136,7 +136,7 @@ def test_singular_values(mca_model):
     ],
 )
 def test_covariance_fraction(mca_model):
-    mca_rotator = ComplexMCARotator(n_modes=4)
+    mca_rotator = HilbertMCARotator(n_modes=4)
     mca_rotator.fit(mca_model)
     cf = mca_rotator.covariance_fraction()
     assert isinstance(cf, xr.DataArray)
@@ -152,12 +152,12 @@ def test_covariance_fraction(mca_model):
     ],
 )
 def test_components(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     comps1, comps2 = mca_rotator.components()
     assert isinstance(comps1, xr.DataArray)
     assert isinstance(comps2, xr.DataArray)
-    # assert that the components are complex valued
+    # assert that the components are Hilbert valued
     assert np.iscomplexobj(comps1)
     assert np.iscomplexobj(comps2)
 
@@ -171,12 +171,12 @@ def test_components(mca_model, mock_data_array, dim):
     ],
 )
 def test_scores(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     scores1, scores2 = mca_rotator.scores()
     assert isinstance(scores1, xr.DataArray)
     assert isinstance(scores2, xr.DataArray)
-    # assert that the scores are complex valued
+    # assert that the scores are Hilbert valued
     assert np.iscomplexobj(scores1)
     assert np.iscomplexobj(scores2)
 
@@ -190,7 +190,7 @@ def test_scores(mca_model, mock_data_array, dim):
     ],
 )
 def test_homogeneous_patterns(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     with pytest.raises(NotImplementedError):
         _ = mca_rotator.homogeneous_patterns()
@@ -205,7 +205,7 @@ def test_homogeneous_patterns(mca_model, mock_data_array, dim):
     ],
 )
 def test_heterogeneous_patterns(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     with pytest.raises(NotImplementedError):
         _ = mca_rotator.heterogeneous_patterns()
@@ -220,7 +220,7 @@ def test_heterogeneous_patterns(mca_model, mock_data_array, dim):
     ],
 )
 def test_components_amplitude(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     amps1, amps2 = mca_rotator.components_amplitude()
 
@@ -234,7 +234,7 @@ def test_components_amplitude(mca_model, mock_data_array, dim):
     ],
 )
 def test_components_phase(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     amps1, amps2 = mca_rotator.components_phase()
 
@@ -248,7 +248,7 @@ def test_components_phase(mca_model, mock_data_array, dim):
     ],
 )
 def test_scores_amplitude(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     amps1, amps2 = mca_rotator.scores_amplitude()
 
@@ -262,6 +262,6 @@ def test_scores_amplitude(mca_model, mock_data_array, dim):
     ],
 )
 def test_scores_phase(mca_model, mock_data_array, dim):
-    mca_rotator = ComplexMCARotator(n_modes=2)
+    mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
     amps1, amps2 = mca_rotator.scores_phase()

--- a/tests/models/test_orthogonality.py
+++ b/tests/models/test_orthogonality.py
@@ -1,8 +1,16 @@
 import numpy as np
 import pytest
 
-from xeofs.models import EOF, ComplexEOF, EOFRotator, ComplexEOFRotator
-from xeofs.models import MCA, ComplexMCA, MCARotator, ComplexMCARotator
+from xeofs.models import (
+    EOF,
+    MCA,
+    EOFRotator,
+    HilbertEOF,
+    HilbertEOFRotator,
+    HilbertMCA,
+    HilbertMCARotator,
+    MCARotator,
+)
 
 
 # Orthogonality
@@ -44,7 +52,7 @@ def test_eof_scores(dim, use_coslat, mock_data_array):
     ), "Scores are not orthogonal"
 
 
-# Complex EOF
+# Hilbert EOF
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -55,7 +63,7 @@ def test_eof_scores(dim, use_coslat, mock_data_array):
 )
 def test_ceof_components(dim, use_coslat, mock_data_array):
     """Components are unitary"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
     V = model.data["components"].values
     assert np.allclose(
@@ -73,7 +81,7 @@ def test_ceof_components(dim, use_coslat, mock_data_array):
 )
 def test_ceof_scores(dim, use_coslat, mock_data_array):
     """Scores are unitary"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
     U = model.data["scores"].values / model.data["norms"].values
     assert np.allclose(
@@ -136,7 +144,7 @@ def test_reof_scores(dim, use_coslat, power, mock_data_array):
         assert not np.allclose(K, np.eye(K.shape[1])), "Components are orthogonal"
 
 
-# Complex rotated EOF
+# Hilbert rotated EOF
 @pytest.mark.parametrize(
     "dim, use_coslat, power",
     [
@@ -150,9 +158,9 @@ def test_reof_scores(dim, use_coslat, power, mock_data_array):
 )
 def test_creof_components(dim, use_coslat, power, mock_data_array):
     """Components are NOT unitary"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
-    rot = ComplexEOFRotator(n_modes=5, power=power)
+    rot = HilbertEOFRotator(n_modes=5, power=power)
     rot.fit(model)
     V = rot.data["components"].values
     K = V.conj().T @ V
@@ -176,9 +184,9 @@ def test_creof_components(dim, use_coslat, power, mock_data_array):
 )
 def test_creof_scores(dim, use_coslat, power, mock_data_array):
     """Components are unitary only for Varimax rotation"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
-    rot = ComplexEOFRotator(n_modes=5, power=power)
+    rot = HilbertEOFRotator(n_modes=5, power=power)
     rot.fit(model)
     U = rot.data["scores"].values / rot.data["norms"].values
     K = U.conj().T @ U
@@ -239,7 +247,7 @@ def test_mca_scores(dim, use_coslat, mock_data_array):
     assert np.allclose(K, target, atol=1e-5), "Scores are not orthogonal"
 
 
-# Complex MCA
+# Hilbert MCA
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -252,7 +260,7 @@ def test_cmca_components(dim, use_coslat, mock_data_array):
     """Components are unitary"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
     V1 = model.data["components1"].values
     V2 = model.data["components2"].values
@@ -278,7 +286,7 @@ def test_cmca_scores(dim, use_coslat, mock_data_array):
     """Scores are unitary"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=10, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=10, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
     U1 = model.data["scores1"].values
     U2 = model.data["scores2"].values
@@ -364,7 +372,7 @@ def test_rmca_scores(dim, use_coslat, power, squared_loadings, mock_data_array):
         assert not np.allclose(K, target), "Components are orthogonal"
 
 
-# Complex Rotated MCA
+# Hilbert Rotated MCA
 @pytest.mark.parametrize(
     "dim, use_coslat, power, squared_loadings",
     [
@@ -386,9 +394,9 @@ def test_crmca_components(dim, use_coslat, power, squared_loadings, mock_data_ar
     """Components are NOT orthogonal"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=19, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=19, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
-    rot = ComplexMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
+    rot = HilbertMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
     rot.fit(model)
     V1 = rot.data["components1"].values
     V2 = rot.data["components2"].values
@@ -426,9 +434,9 @@ def test_crmca_scores(dim, use_coslat, power, squared_loadings, mock_data_array)
     """Components are orthogonal only for Varimax rotation"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
-    rot = ComplexMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
+    rot = HilbertMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
     rot.fit(model)
     U1 = rot.data["scores1"].values
     U2 = rot.data["scores2"].values
@@ -469,7 +477,7 @@ def test_eof_transform(dim, use_coslat, mock_data_array, normalized):
     ), "Transformed data does not match the scores"
 
 
-# Complex EOF
+# Hilbert EOF
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -481,7 +489,7 @@ def test_eof_transform(dim, use_coslat, mock_data_array, normalized):
 @pytest.mark.parametrize("normalized", [True, False])
 def test_ceof_transform(dim, use_coslat, mock_data_array, normalized):
     """Not implemented yet"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
     model.scores(normalized=normalized)
     with pytest.raises(NotImplementedError):
@@ -517,7 +525,7 @@ def test_reof_transform(dim, use_coslat, power, mock_data_array, normalized):
     )
 
 
-# Complex Rotated EOF
+# Hilbert Rotated EOF
 @pytest.mark.parametrize(
     "dim, use_coslat, power",
     [
@@ -532,9 +540,9 @@ def test_reof_transform(dim, use_coslat, power, mock_data_array, normalized):
 @pytest.mark.parametrize("normalized", [True, False])
 def test_creof_transform(dim, use_coslat, power, mock_data_array, normalized):
     """not implemented yet"""
-    model = ComplexEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(mock_data_array, dim=dim)
-    rot = ComplexEOFRotator(n_modes=5, power=power)
+    rot = HilbertEOFRotator(n_modes=5, power=power)
     rot.fit(model)
     rot.scores(normalized=normalized)
     with pytest.raises(NotImplementedError):
@@ -566,7 +574,7 @@ def test_mca_transform(dim, use_coslat, mock_data_array):
     ), "Transformed data does not match the scores"
 
 
-# Complex MCA
+# Hilbert MCA
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -579,7 +587,7 @@ def test_cmca_transform(dim, use_coslat, mock_data_array):
     """Transforming the original data results in the model scores"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
     scores1, scores2 = model.scores()
     with pytest.raises(NotImplementedError):
@@ -622,7 +630,7 @@ def test_rmca_transform(dim, use_coslat, power, squared_loadings, mock_data_arra
     ), "Transformed data does not match the scores"
 
 
-# Complex Rotated MCA
+# Hilbert Rotated MCA
 @pytest.mark.parametrize(
     "dim, use_coslat, power, squared_loadings",
     [
@@ -644,9 +652,9 @@ def test_crmca_transform(dim, use_coslat, power, squared_loadings, mock_data_arr
     """Transforming the original data results in the model scores"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=5, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
-    rot = ComplexMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
+    rot = HilbertMCARotator(n_modes=5, power=power, squared_loadings=squared_loadings)
     rot.fit(model)
     scores1, scores2 = rot.scores()
     with pytest.raises(NotImplementedError):
@@ -702,7 +710,7 @@ def test_eof_inverse_transform(dim, use_coslat, mock_data_array, normalized):
     assert r2 > 0.95, "Inverse transform does not produce a good reconstruction"
 
 
-# Complex EOF
+# Hilbert EOF
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -715,7 +723,7 @@ def test_eof_inverse_transform(dim, use_coslat, mock_data_array, normalized):
 def test_ceof_inverse_transform(dim, use_coslat, mock_data_array, normalized):
     """Inverse transform produces an approximate reconstruction of the original data"""
     data = mock_data_array
-    model = ComplexEOF(n_modes=19, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=19, standardize=True, use_coslat=use_coslat)
     model.fit(data, dim=dim)
     scores = model.scores(normalized=normalized)
     data_rec = model.inverse_transform(scores, normalized=normalized).real
@@ -755,7 +763,7 @@ def test_reof_inverse_transform(dim, use_coslat, power, mock_data_array, normali
     ), f"Inverse transform does not produce a good reconstruction (R2={r2.values:.2f})"
 
 
-# Complex Rotated EOF
+# Hilbert Rotated EOF
 @pytest.mark.parametrize(
     "dim, use_coslat, power",
     [
@@ -771,9 +779,9 @@ def test_reof_inverse_transform(dim, use_coslat, power, mock_data_array, normali
 def test_creof_inverse_transform(dim, use_coslat, power, mock_data_array, normalized):
     """Inverse transform produces an approximate reconstruction of the original data"""
     data = mock_data_array
-    model = ComplexEOF(n_modes=19, standardize=True, use_coslat=use_coslat)
+    model = HilbertEOF(n_modes=19, standardize=True, use_coslat=use_coslat)
     model.fit(data, dim=dim)
-    rot = ComplexEOFRotator(n_modes=19, power=power)
+    rot = HilbertEOFRotator(n_modes=19, power=power)
     rot.fit(model)
     scores = rot.scores(normalized=normalized)
     data_rec = rot.inverse_transform(scores, normalized=normalized).real
@@ -816,7 +824,7 @@ def test_mca_inverse_transform(dim, use_coslat, mock_data_array):
     ), f"Inverse transform does not produce a good reconstruction of right field (R2={r2_2.values:.2f})"
 
 
-# Complex MCA
+# Hilbert MCA
 @pytest.mark.parametrize(
     "dim, use_coslat",
     [
@@ -829,7 +837,7 @@ def test_cmca_inverse_transform(dim, use_coslat, mock_data_array):
     """Inverse transform produces an approximate reconstruction of the original data"""
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=19, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=19, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
     scores1 = model.data["scores1"]
     scores2 = model.data["scores2"]
@@ -891,7 +899,7 @@ def test_rmca_inverse_transform(
     ), f"Inverse transform does not produce a good reconstruction of right field (R2={r2_2.values:.2f})"
 
 
-# Complex Rotated MCA
+# Hilbert Rotated MCA
 @pytest.mark.parametrize(
     "dim, use_coslat, power, squared_loadings",
     [
@@ -913,15 +921,15 @@ def test_crmca_inverse_transform(
     dim, use_coslat, power, squared_loadings, mock_data_array
 ):
     """Inverse transform produces an approximate reconstruction of the original data"""
-    # NOTE: The lobpcg SVD solver for complex matrices requires a small number of modes
+    # NOTE: The lobpcg SVD solver for Hilbert matrices requires a small number of modes
     # compared to the actual data size. Since we have a small test set here we only use
     # 10 modes for the test. Therefore, the threshold for the R2 score is lower than for
     # the other tests.
     data1 = mock_data_array.copy()
     data2 = data1.copy() ** 2
-    model = ComplexMCA(n_modes=10, standardize=True, use_coslat=use_coslat)
+    model = HilbertMCA(n_modes=10, standardize=True, use_coslat=use_coslat)
     model.fit(data1, data2, dim=dim)
-    rot = ComplexMCARotator(n_modes=10, power=power, squared_loadings=squared_loadings)
+    rot = HilbertMCARotator(n_modes=10, power=power, squared_loadings=squared_loadings)
     rot.fit(model)
     scores1 = rot.data["scores1"]
     scores2 = rot.data["scores2"]

--- a/tests/models/test_rotator.py
+++ b/tests/models/test_rotator.py
@@ -1,7 +1,15 @@
 import pytest
 
-from xeofs.models import EOF, ComplexEOF, MCA, ComplexMCA
-from xeofs.models import EOFRotator, ComplexEOFRotator, MCARotator, ComplexMCARotator
+from xeofs.models import (
+    EOF,
+    MCA,
+    EOFRotator,
+    HilbertEOF,
+    HilbertEOFRotator,
+    HilbertMCA,
+    HilbertMCARotator,
+    MCARotator,
+)
 from xeofs.models.rotator_factory import RotatorFactory
 
 # RotatorFactory should be imported from its module
@@ -11,7 +19,7 @@ from xeofs.models.rotator_factory import RotatorFactory
 def test_rotator_factory_init():
     factory = RotatorFactory(n_modes=3, power=2, max_iter=1000, rtol=1e-8)
     assert factory.params == {"n_modes": 3, "power": 2, "max_iter": 1000, "rtol": 1e-8}
-    assert factory._valid_types == (EOF, ComplexEOF, MCA, ComplexMCA)
+    assert factory._valid_types == (EOF, HilbertEOF, MCA, HilbertMCA)
 
 
 def test_create_rotator_EOF():
@@ -21,11 +29,11 @@ def test_create_rotator_EOF():
     assert isinstance(rotator, EOFRotator)
 
 
-def test_create_rotator_ComplexEOF():
+def test_create_rotator_HilbertEOF():
     factory = RotatorFactory(n_modes=3, power=2, max_iter=1000, rtol=1e-8)
-    ComplexEOF_instance = ComplexEOF()  # creating instance of the mock class
-    rotator = factory.create_rotator(ComplexEOF_instance)
-    assert isinstance(rotator, ComplexEOFRotator)
+    HilbertEOF_instance = HilbertEOF()  # creating instance of the mock class
+    rotator = factory.create_rotator(HilbertEOF_instance)
+    assert isinstance(rotator, HilbertEOFRotator)
 
 
 def test_create_rotator_MCA():
@@ -35,11 +43,11 @@ def test_create_rotator_MCA():
     assert isinstance(rotator, MCARotator)
 
 
-def test_create_rotator_ComplexMCA():
+def test_create_rotator_HilbertMCA():
     factory = RotatorFactory(n_modes=3, power=2, max_iter=1000, rtol=1e-8)
-    ComplexMCA_instance = ComplexMCA()
-    rotator = factory.create_rotator(ComplexMCA_instance)
-    assert isinstance(rotator, ComplexMCARotator)
+    HilbertMCA_instance = HilbertMCA()
+    rotator = factory.create_rotator(HilbertMCA_instance)
+    assert isinstance(rotator, HilbertMCARotator)
 
 
 def test_create_rotator_invalid_model():

--- a/xeofs/models/__init__.py
+++ b/xeofs/models/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .cca import CCA
 from .eeof import ExtendedEOF
 from .eof import EOF, HilbertEOF
@@ -25,3 +27,28 @@ __all__ = [
     "RotatorFactory",
     "SparsePCA",
 ]
+
+
+DEPRECATED_NAMES = [
+    ("ComplexEOF", "HilbertEOF"),
+    ("ComplexMCA", "HilbertMCA"),
+    ("ComplexEOFRotator", "HilbertEOFRotator"),
+    ("ComplexMCARotator", "HilbertMCARotator"),
+]
+
+
+def __dir__():
+    return sorted(__all__ + [names[0] for names in DEPRECATED_NAMES])
+
+
+def __getattr__(name):
+    for old_name, new_name in DEPRECATED_NAMES:
+        if name == old_name:
+            msg = (
+                f"Class '{old_name}' is deprecated and will be renamed to '{new_name}' in the next major release. "
+                f"In that release, '{old_name}' will refer to a different class. "
+                f"Please switch to '{new_name}' to maintain compatibility."
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            return globals()[new_name]
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/xeofs/models/__init__.py
+++ b/xeofs/models/__init__.py
@@ -1,26 +1,26 @@
 from .cca import CCA
 from .eeof import ExtendedEOF
-from .eof import EOF, ComplexEOF
-from .eof_rotator import ComplexEOFRotator, EOFRotator
+from .eof import EOF, HilbertEOF
+from .eof_rotator import EOFRotator, HilbertEOFRotator
 from .gwpca import GWPCA
-from .mca import MCA, ComplexMCA
-from .mca_rotator import ComplexMCARotator, MCARotator
+from .mca import MCA, HilbertMCA
+from .mca_rotator import HilbertMCARotator, MCARotator
 from .opa import OPA
 from .rotator_factory import RotatorFactory
 from .sparse_pca import SparsePCA
 
 __all__ = [
     "EOF",
-    "ComplexEOF",
+    "HilbertEOF",
     "ExtendedEOF",
     "EOFRotator",
-    "ComplexEOFRotator",
+    "HilbertEOFRotator",
     "OPA",
     "GWPCA",
     "MCA",
-    "ComplexMCA",
+    "HilbertMCA",
     "MCARotator",
-    "ComplexMCARotator",
+    "HilbertMCARotator",
     "CCA",
     "RotatorFactory",
     "SparsePCA",

--- a/xeofs/models/eof.py
+++ b/xeofs/models/eof.py
@@ -1,14 +1,15 @@
-from typing import Optional, Dict
-from typing_extensions import Self
+from typing import Dict, Optional
+
 import numpy as np
 import xarray as xr
+from typing_extensions import Self
 
+from ..utils.data_types import DataArray, DataObject
+from ..utils.hilbert_transform import hilbert_transform
+from ..utils.sanity_checks import assert_not_complex
+from ..utils.xarray_utils import total_variance as compute_total_variance
 from ._base_model import _BaseModel
 from .decomposer import Decomposer
-from ..utils.data_types import DataObject, DataArray
-from ..utils.hilbert_transform import hilbert_transform
-from ..utils.xarray_utils import total_variance as compute_total_variance
-from ..utils.sanity_checks import assert_not_complex
 
 
 class EOF(_BaseModel):
@@ -239,10 +240,10 @@ class EOF(_BaseModel):
         return exp_var_ratio
 
 
-class ComplexEOF(EOF):
-    """Complex EOF analysis.
+class HilbertEOF(EOF):
+    """Hilbert EOF analysis.
 
-    The Complex EOF analysis [1]_ [2]_ [3]_ [4]_ (also known as Hilbert EOF analysis) applies a Hilbert transform
+    The Hilbert EOF analysis [1]_ [2]_ [3]_ [4]_ (also known as Hilbert EOF analysis) applies a Hilbert transform
     to the data before performing the standard EOF analysis.
     The Hilbert transform is applied to each feature of the data individually.
 
@@ -299,7 +300,7 @@ class ComplexEOF(EOF):
 
     Examples
     --------
-    >>> model = ComplexEOF(n_modes=5, standardize=True)
+    >>> model = HilbertEOF(n_modes=5, standardize=True)
     >>> model.fit(data)
 
     """
@@ -337,7 +338,7 @@ class ComplexEOF(EOF):
             solver_kwargs=solver_kwargs,
             **kwargs,
         )
-        self.attrs.update({"model": "Complex EOF analysis"})
+        self.attrs.update({"model": "Hilbert EOF analysis"})
         self._params.update({"padding": padding, "decay_factor": decay_factor})
 
     def _fit_algorithm(self, data: DataArray) -> Self:
@@ -385,7 +386,7 @@ class ComplexEOF(EOF):
         return self
 
     def _transform_algorithm(self, data: DataArray) -> DataArray:
-        raise NotImplementedError("Complex EOF does not support transform method.")
+        raise NotImplementedError("Hilbert EOF does not support transform method.")
 
     def _inverse_transform_algorithm(self, scores: DataArray) -> DataArray:
         Xrec = super()._inverse_transform_algorithm(scores)

--- a/xeofs/models/eof_rotator.py
+++ b/xeofs/models/eof_rotator.py
@@ -5,13 +5,13 @@ import numpy as np
 import xarray as xr
 from typing_extensions import Self
 
-from .eof import EOF, ComplexEOF
+from .._version import __version__
 from ..data_container import DataContainer
 from ..preprocessing.preprocessor import Preprocessor
-from ..utils.rotation import promax
 from ..utils.data_types import DataArray
+from ..utils.rotation import promax
 from ..utils.xarray_utils import argsort_dask, get_deterministic_sign_multiplier
-from .._version import __version__
+from .eof import EOF, HilbertEOF
 
 
 class EOFRotator(EOF):
@@ -287,10 +287,10 @@ class EOFRotator(EOF):
         return rotation_matrix
 
 
-class ComplexEOFRotator(EOFRotator, ComplexEOF):
-    """Rotate a solution obtained from ``xe.models.ComplexEOF``.
+class HilbertEOFRotator(EOFRotator, HilbertEOF):
+    """Rotate a solution obtained from ``xe.models.HilbertEOF``.
 
-    Complex Rotated EOF analysis [1]_ [2]_ [3]_ extends EOF analysis by incorporating both amplitude and phase information
+    Hilbert Rotated EOF analysis [1]_ [2]_ [3]_ extends EOF analysis by incorporating both amplitude and phase information
     using a Hilbert transform prior to performing MCA and subsequent Varimax or Promax rotation.
     This adds a further layer of dimensionality to the analysis, allowing for a more nuanced interpretation
     of complex relationships within the data, particularly useful when analyzing oscillatory data.
@@ -319,9 +319,9 @@ class ComplexEOFRotator(EOFRotator, ComplexEOF):
 
     Examples
     --------
-    >>> model = xe.models.ComplexEOF(n_modes=10)
+    >>> model = xe.models.HilbertEOF(n_modes=10)
     >>> model.fit(data)
-    >>> rotator = xe.models.ComplexEOFRotator(n_modes=10)
+    >>> rotator = xe.models.HilbertEOFRotator(n_modes=10)
     >>> rotator.fit(model)
     >>> rotator.components()
 
@@ -339,13 +339,13 @@ class ComplexEOFRotator(EOFRotator, ComplexEOF):
         super().__init__(
             n_modes=n_modes, power=power, max_iter=max_iter, rtol=rtol, compute=compute
         )
-        self.attrs.update({"model": "Rotated Complex EOF analysis"})
-        self.model = ComplexEOF()
+        self.attrs.update({"model": "Rotated Hilbert EOF analysis"})
+        self.model = HilbertEOF()
 
     def _transform_algorithm(self, data: DataArray) -> DataArray:
         # Here we leverage the Method Resolution Order (MRO) to invoke the
         # transform method of the first class in the MRO after EOFRotator that
-        # has a transform method. In this case, it will be ComplexEOF. However,
-        # please note that `transform` is not implemented for ComplexEOF, so this
+        # has a transform method. In this case, it will be HilbertEOF. However,
+        # please note that `transform` is not implemented for HilbertEOF, so this
         # line of code will actually raise an error.
         return super(EOFRotator, self)._transform_algorithm(data)

--- a/xeofs/models/mca.py
+++ b/xeofs/models/mca.py
@@ -1,18 +1,18 @@
 import warnings
-from typing import Tuple, Optional, Sequence, Dict
-from typing_extensions import Self
+from typing import Dict, Optional, Sequence, Tuple
 
 import numpy as np
 import xarray as xr
+from typing_extensions import Self
 
+from ..utils.data_types import DataArray, DataObject
+from ..utils.dimension_renamer import DimensionRenamer
+from ..utils.hilbert_transform import hilbert_transform
+from ..utils.sanity_checks import assert_not_complex
+from ..utils.statistics import pearson_correlation
+from ..utils.xarray_utils import argsort_dask
 from ._base_cross_model import _BaseCrossModel
 from .decomposer import Decomposer
-from ..utils.data_types import DataObject, DataArray
-from ..utils.statistics import pearson_correlation
-from ..utils.hilbert_transform import hilbert_transform
-from ..utils.dimension_renamer import DimensionRenamer
-from ..utils.xarray_utils import argsort_dask
-from ..utils.sanity_checks import assert_not_complex
 
 
 class MCA(_BaseCrossModel):
@@ -554,10 +554,10 @@ class MCA(_BaseCrossModel):
             )
 
 
-class ComplexMCA(MCA):
-    """Complex MCA.
+class HilbertMCA(MCA):
+    """Hilbert MCA.
 
-    Complex MCA, also referred to as Analytical SVD (ASVD) by Elipot et al. (2017) [1]_,
+    Hilbert MCA, also referred to as Analytical SVD (ASVD) by Elipot et al. (2017) [1]_,
     enhances traditional MCA by accommodating both amplitude and phase information.
     It achieves this by utilizing the Hilbert transform to preprocess the data,
     thus allowing for a more comprehensive analysis in the subsequent MCA computation.
@@ -612,12 +612,12 @@ class ComplexMCA(MCA):
 
     Notes
     -----
-    Complex MCA extends MCA to complex-valued data that contain both magnitude and phase information.
+    Hilbert MCA extends MCA to complex-valued data that contain both magnitude and phase information.
     The Hilbert transform is used to transform real-valued data to complex-valued data, from which both
     amplitude and phase can be extracted.
 
-    Similar to MCA, Complex MCA is used in climate science to identify coupled patterns of variability
-    between two different climate variables. But unlike MCA, Complex MCA can identify coupled patterns
+    Similar to MCA, Hilbert MCA is used in climate science to identify coupled patterns of variability
+    between two different climate variables. But unlike MCA, Hilbert MCA can identify coupled patterns
     that involve phase shifts.
 
     References
@@ -628,7 +628,7 @@ class ComplexMCA(MCA):
 
     Examples
     --------
-    >>> model = ComplexMCA(n_modes=5, standardize=True)
+    >>> model = HilbertMCA(n_modes=5, standardize=True)
     >>> model.fit(data1, data2)
 
     """
@@ -666,7 +666,7 @@ class ComplexMCA(MCA):
             solver_kwargs=solver_kwargs,
             **kwargs,
         )
-        self.attrs.update({"model": "Complex MCA"})
+        self.attrs.update({"model": "Hilbert MCA"})
         self._params.update({"padding": padding, "decay_factor": decay_factor})
 
     def _fit_algorithm(self, data1: DataArray, data2: DataArray) -> Self:
@@ -900,7 +900,7 @@ class ComplexMCA(MCA):
         return (scores1, scores2)
 
     def transform(self, data1: DataObject, data2: DataObject):
-        raise NotImplementedError("Complex MCA does not support transform method.")
+        raise NotImplementedError("Hilbert MCA does not support transform method.")
 
     def _inverse_transform_algorithm(self, scores1: DataArray, scores2: DataArray):
         data1, data2 = super()._inverse_transform_algorithm(scores1, scores2)
@@ -910,10 +910,10 @@ class ComplexMCA(MCA):
 
     def homogeneous_patterns(self, correction=None, alpha=0.05):
         raise NotImplementedError(
-            "Complex MCA does not support homogeneous_patterns method."
+            "Hilbert MCA does not support homogeneous_patterns method."
         )
 
     def heterogeneous_patterns(self, correction=None, alpha=0.05):
         raise NotImplementedError(
-            "Complex MCA does not support heterogeneous_patterns method."
+            "Hilbert MCA does not support heterogeneous_patterns method."
         )

--- a/xeofs/models/mca_rotator.py
+++ b/xeofs/models/mca_rotator.py
@@ -1,16 +1,17 @@
 from datetime import datetime
+from typing import Dict, List
+
 import numpy as np
 import xarray as xr
-from typing import List, Dict
 from typing_extensions import Self
 
-from .mca import MCA, ComplexMCA
-from ..preprocessing.preprocessor import Preprocessor
-from ..utils.rotation import promax
-from ..utils.data_types import DataArray, DataObject
-from ..utils.xarray_utils import argsort_dask, get_deterministic_sign_multiplier
-from ..data_container import DataContainer
 from .._version import __version__
+from ..data_container import DataContainer
+from ..preprocessing.preprocessor import Preprocessor
+from ..utils.data_types import DataArray, DataObject
+from ..utils.rotation import promax
+from ..utils.xarray_utils import argsort_dask, get_deterministic_sign_multiplier
+from .mca import MCA, HilbertMCA
 
 
 class MCARotator(MCA):
@@ -410,10 +411,10 @@ class MCARotator(MCA):
             return results
 
 
-class ComplexMCARotator(MCARotator, ComplexMCA):
-    """Rotate a solution obtained from ``xe.models.ComplexMCA``.
+class HilbertMCARotator(MCARotator, HilbertMCA):
+    """Rotate a solution obtained from ``xe.models.HilbertMCA``.
 
-    Complex Rotated MCA [1]_ [2]_ [3]_ extends MCA by incorporating both amplitude and phase information
+    Hilbert Rotated MCA [1]_ [2]_ [3]_ extends MCA by incorporating both amplitude and phase information
     using a Hilbert transform prior to performing MCA and subsequent Varimax or Promax rotation.
     This adds a further layer of dimensionality to the analysis, allowing for a more nuanced interpretation
     of complex relationships within the data, particularly useful when analyzing oscillatory data.
@@ -450,9 +451,9 @@ class ComplexMCARotator(MCARotator, ComplexMCA):
 
     Examples
     --------
-    >>> model = ComplexMCA(n_modes=5)
+    >>> model = HilbertMCA(n_modes=5)
     >>> model.fit(da1, da2, dim='time')
-    >>> rotator = ComplexMCARotator(n_modes=5, power=2)
+    >>> rotator = HilbertMCARotator(n_modes=5, power=2)
     >>> rotator.fit(model)
     >>> rotator.components()
 
@@ -460,13 +461,13 @@ class ComplexMCARotator(MCARotator, ComplexMCA):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.attrs.update({"model": "Complex Rotated MCA"})
-        self.model = ComplexMCA()
+        self.attrs.update({"model": "Hilbert Rotated MCA"})
+        self.model = HilbertMCA()
 
     def transform(self, **kwargs):
         # Here we make use of the Method Resolution Order (MRO) to call the
         # transform method of the first class in the MRO after `MCARotator`
-        # that has a transform method. In this case it will be `ComplexMCA`,
+        # that has a transform method. In this case it will be `HilbertMCA`,
         # which will raise an error because it does not have a transform method.
         super(MCARotator, self).transform(**kwargs)
 

--- a/xeofs/models/rotator_factory.py
+++ b/xeofs/models/rotator_factory.py
@@ -1,7 +1,7 @@
-from .eof import EOF, ComplexEOF
-from .eof_rotator import ComplexEOFRotator, EOFRotator
-from .mca import MCA, ComplexMCA
-from .mca_rotator import ComplexMCARotator, MCARotator
+from .eof import EOF, HilbertEOF
+from .eof_rotator import EOFRotator, HilbertEOFRotator
+from .mca import MCA, HilbertMCA
+from .mca_rotator import HilbertMCARotator, MCARotator
 
 
 class RotatorFactory:
@@ -25,11 +25,11 @@ class RotatorFactory:
 
     def __init__(self, **kwargs):
         self.params = kwargs
-        self._valid_types = (EOF, ComplexEOF, MCA, ComplexMCA)
+        self._valid_types = (EOF, HilbertEOF, MCA, HilbertMCA)
 
     def create_rotator(
-        self, model: EOF | ComplexEOF | MCA | ComplexMCA
-    ) -> EOFRotator | ComplexEOFRotator | MCARotator | ComplexMCARotator:
+        self, model: EOF | HilbertEOF | MCA | HilbertMCA
+    ) -> EOFRotator | HilbertEOFRotator | MCARotator | HilbertMCARotator:
         """Create a rotator for the given model.
 
         Parameters
@@ -46,12 +46,12 @@ class RotatorFactory:
         # of inheritance.
         if type(model) is EOF:
             return EOFRotator(**self.params)
-        elif type(model) is ComplexEOF:
-            return ComplexEOFRotator(**self.params)
+        elif type(model) is HilbertEOF:
+            return HilbertEOFRotator(**self.params)
         elif type(model) is MCA:
             return MCARotator(**self.params)
-        elif type(model) is ComplexMCA:
-            return ComplexMCARotator(**self.params)
+        elif type(model) is HilbertMCA:
+            return HilbertMCARotator(**self.params)
         else:
             err_msg = f"Invalid model type. Valid types are {self._valid_types}."
             raise TypeError(err_msg)


### PR DESCRIPTION
With the upcoming release v3.0 in mind, this deprecation warning is intended to prepare users for the renaming of the `Complex` classes (#188 ).