### PR TITLE
feat: change default value of parameter `normalized`

### DIFF
--- a/xeofs/models/_base_model_cross_set.py
+++ b/xeofs/models/_base_model_cross_set.py
@@ -317,7 +317,7 @@ class _BaseModelCrossSet(_BaseModel):
         X, Y: DataObject | None
             Data to be transformed. At least one of them must be provided.
         normalized: bool, default=False
-            Whether to return normalized scores.
+            Whether to return L2 normalized scores.
 
         Returns
         -------

--- a/xeofs/models/cpcca_rotator.py
+++ b/xeofs/models/cpcca_rotator.py
@@ -310,19 +310,19 @@ class CPCCARotator(CPCCA):
         Y: DataObject | None = None,
         normalized: bool = False,
     ) -> DataArray | List[DataArray]:
-        """Project new "unseen" data onto the rotated singular vectors.
+        """Transform the data.
 
         Parameters
         ----------
-        X : DataObject
-            Data to be projected onto the rotated singular vectors of the first dataset.
-        Y : DataObject
-            Data to be projected onto the rotated singular vectors of the second dataset.
+        X, Y: DataObject | None
+            Data to be transformed. At least one of them must be provided.
+        normalized: bool, default=False
+            Whether to return L2 normalized scores.
 
         Returns
         -------
-        DataArray | List[DataArray]
-            Projected data.
+        Sequence[DataArray] | DataArray
+            Transformed data.
 
         """
         # raise error if no data is provided

--- a/xeofs/models/eof.py
+++ b/xeofs/models/eof.py
@@ -156,11 +156,10 @@ class EOF(_BaseModelSingleSet):
 
         return reconstructed_data
 
-    def components(self) -> DataObject:
-        """Return the (EOF) components.
+    def components(self, normalized: bool = True) -> DataObject:
+        """Return the components.
 
-        The components in EOF anaylsis are the eigenvectors of the covariance/correlation matrix.
-        Other names include the principal components or EOFs.
+        The components are also refered to as eigenvectors, EOFs or loadings depending on the context.
 
         Returns
         -------
@@ -168,9 +167,9 @@ class EOF(_BaseModelSingleSet):
             Components of the fitted model.
 
         """
-        return super().components()
+        return super().components(normalized=normalized)
 
-    def scores(self, normalized: bool = True) -> DataArray:
+    def scores(self, normalized: bool = False) -> DataArray:
         """Return the (PC) scores.
 
         The scores in EOF anaylsis are the projection of the data matrix onto the
@@ -341,7 +340,7 @@ class ComplexEOF(EOF):
 
         return super()._fit_algorithm(X)
 
-    def components_amplitude(self) -> DataObject:
+    def components_amplitude(self, normalized=True) -> DataObject:
         """Return the amplitude of the (EOF) components.
 
         The amplitude of the components are defined as
@@ -352,6 +351,11 @@ class ComplexEOF(EOF):
         where :math:`C_{ij}` is the :math:`i`-th entry of the :math:`j`-th component and
         :math:`|\\cdot|` denotes the absolute value.
 
+        Parameters
+        ----------
+        normalized : bool, default=True
+            Whether to normalize the components by the singular values
+
         Returns
         -------
         components_amplitude: DataArray | Dataset | List[DataArray]
@@ -359,6 +363,10 @@ class ComplexEOF(EOF):
 
         """
         amplitudes = abs(self.data["components"])
+
+        if not normalized:
+            amplitudes = amplitudes * self.data["norms"]
+
         amplitudes.name = "components_amplitude"
         return self.preprocessor.inverse_transform_components(amplitudes)
 

--- a/xeofs/models/sparse_pca.py
+++ b/xeofs/models/sparse_pca.py
@@ -297,7 +297,7 @@ class SparsePCA(_BaseModelSingleSet):
         """
         return super().components()
 
-    def scores(self, normalized: bool = True) -> DataArray:
+    def scores(self, normalized: bool = False) -> DataArray:
         """Return the component scores.
 
         The component scores :math:`U` are defined as the projection of the fitted
@@ -309,7 +309,7 @@ class SparsePCA(_BaseModelSingleSet):
 
         Parameters
         ----------
-        normalized : bool, default=True
+        normalized : bool, default=False
             Whether to normalize the scores by the L2 norm.
 
         Returns


### PR DESCRIPTION
For `scores` switch from `True` to `False` to align more closely with the scikit-learn convention. For `components`, keep `True`.