### PR TITLE
fix(cross): compute total squared covariance in PC space

### DIFF
--- a/xeofs/cross/cpcca.py
+++ b/xeofs/cross/cpcca.py
@@ -982,8 +982,8 @@ class CPCCA(BaseModelCrossSet):
 
         Requires the unwhitened covariance matrix which we can obtain by multiplying the whitened covariance matrix with the inverse of the whitening transformation matrix.
         """
-        C = self.whitener2.inverse_transform_data(C)
-        C = self.whitener1.inverse_transform_data(C.conj().T)
+        C = self.whitener2.inverse_transform_data(C, unwhiten_only=True)
+        C = self.whitener1.inverse_transform_data(C.conj().T, unwhiten_only=True)
         # Not necessary to conjugate transpose for total squared covariance
         # C = C.conj().T
         return (abs(C) ** 2).sum()


### PR DESCRIPTION
Before, we computed the TSC in the original (physical) space which required computing a large covariance matrix. As a result, we ran out of memory even for datasets of moderate size. Now we compute the TSC in PC space.