### PR TITLE
chore(release): 3.0.1

### DIFF
--- a/xeofs/cross/base_model_cross_set.py
+++ b/xeofs/cross/base_model_cross_set.py
@@ -298,7 +298,7 @@ class BaseModelCrossSet(BaseModel):
         X = self.whitener1.fit_transform(X)
         Y = self.whitener2.fit_transform(Y)
         # Augment data
-        X, y = self._augment_data(X, Y)
+        X, Y = self._augment_data(X, Y)
         # Fit the model
         self._fit_algorithm(X, Y)
 

--- a/xeofs/cross/cpcca.py
+++ b/xeofs/cross/cpcca.py
@@ -982,8 +982,8 @@ class CPCCA(BaseModelCrossSet):
 
         Requires the unwhitened covariance matrix which we can obtain by multiplying the whitened covariance matrix with the inverse of the whitening transformation matrix.
         """
-        C = self.whitener2.inverse_transform_data(C)
-        C = self.whitener1.inverse_transform_data(C.conj().T)
+        C = self.whitener2.inverse_transform_data(C, unwhiten_only=True)
+        C = self.whitener1.inverse_transform_data(C.conj().T, unwhiten_only=True)
         # Not necessary to conjugate transpose for total squared covariance
         # C = C.conj().T
         return (abs(C) ** 2).sum()


### PR DESCRIPTION
This fix solves some regressions introduced in v3 for the cross-set classes:

- Hilbert cross-set models did not transform `Y` data correctly ([960f744](https://github.com/xarray-contrib/xeofs/pull/223/commits/960f74429a01d614bd9289d762550128206330a0)) (close #219)
- Total squared covariance was computed in physical rather than PC space resulting in unnecessary memory consumption ([2dd3e86](https://github.com/xarray-contrib/xeofs/pull/223/commits/2dd3e86d1b41416346a31c6dffd261834990426b)) (close #220)