### PR TITLE
fix: xarray 2024.09.0 compatility

### DIFF
--- a/xeofs/base_model.py
+++ b/xeofs/base_model.py
@@ -90,7 +90,7 @@ class BaseModel(ABC):
         """Serialize a complete model with its preprocessor."""
         # Create a root node for this object with its params as attrs
         ds_root = xr.Dataset(attrs=dict(params=self.get_params()))
-        dt = DataTree(data=ds_root, name=type(self).__name__)
+        dt = DataTree(ds_root, name=type(self).__name__)
 
         # Retrieve the tree representation of each attached object, or set basic attrs
         for key, attr in self.get_serialization_attrs().items():

--- a/xeofs/data_container/data_container.py
+++ b/xeofs/data_container/data_container.py
@@ -36,7 +36,7 @@ class DataContainer(dict):
         for key, data in self.items():
             if not data.name:
                 data.name = key
-            dt[key] = DataTree(data)
+            dt[key] = DataTree(data.to_dataset())
             dt[key].attrs = {key: "_is_node", "allow_compute": self._allow_compute[key]}
 
         return dt

--- a/xeofs/preprocessing/preprocessor.py
+++ b/xeofs/preprocessing/preprocessor.py
@@ -391,7 +391,6 @@ class Preprocessor(Transformer):
                 dt_transformer = transformer_obj.serialize()
             # Place the serialized transformer in the tree
             dt[name] = dt_transformer
-            dt[name].parent = dt
 
         return dt
 

--- a/xeofs/preprocessing/transformer.py
+++ b/xeofs/preprocessing/transformer.py
@@ -140,7 +140,7 @@ class Transformer(BaseEstimator, TransformerMixin, ABC):
             if isinstance(attr, (xr.DataArray, xr.Dataset)):
                 # attach data to data_vars or coords
                 ds = self._serialize_data(key, attr)
-                dt[key] = DataTree(name=key, data=ds)
+                dt[key] = DataTree(ds, name=key)
                 dt.attrs[key] = "_is_node"
             elif isinstance(attr, dict) and any(
                 [isinstance(val, xr.DataArray) for val in attr.values()]
@@ -149,7 +149,7 @@ class Transformer(BaseEstimator, TransformerMixin, ABC):
                 dt_attr = DataTree()
                 for k, v in attr.items():
                     ds = self._serialize_data(k, v)
-                    dt_attr[k] = DataTree(name=k, data=ds)
+                    dt_attr[k] = DataTree(ds, name=k)
                 dt[key] = dt_attr
                 dt.attrs[key] = "_is_tree"
             else:


### PR DESCRIPTION
closes #226 

Lot's of changes to datatree on xarray main since the latest release. These 3 all tripped us up:

https://github.com/pydata/xarray/pull/9297
https://github.com/pydata/xarray/pull/9444
https://github.com/pydata/xarray/pull/9476

Maybe it was a little early to [enable](https://github.com/xarray-contrib/xeofs/pull/169) using the migrated datatree since it's not technically public API yet but I suppose it let's us fix these issues quickly.