### PR TITLE
perf: avoid redundant data when saving Rotator models

### DIFF
--- a/tests/models/cross/test_hilbert_mca_rotator.py
+++ b/tests/models/cross/test_hilbert_mca_rotator.py
@@ -40,7 +40,7 @@ def test_fit(mca_model):
     mca_rotator = HilbertMCARotator(n_modes=2)
     mca_rotator.fit(mca_model)
 
-    assert hasattr(mca_rotator, "model")
+    assert hasattr(mca_rotator, "model_data")
     assert hasattr(mca_rotator, "data")
 
 

--- a/tests/models/cross/test_mca_rotator.py
+++ b/tests/models/cross/test_mca_rotator.py
@@ -43,7 +43,7 @@ def test_fit(mca_model):
     mca_rotator = MCARotator(n_modes=4)
     mca_rotator.fit(mca_model)
 
-    assert hasattr(mca_rotator, "model")
+    assert hasattr(mca_rotator, "model_data")
     assert hasattr(mca_rotator, "data")
 
 

--- a/tests/models/single/test_eof_rotator.py
+++ b/tests/models/single/test_eof_rotator.py
@@ -45,12 +45,12 @@ def test_fit(eof_model):
     eof_rotator.fit(eof_model)
 
     assert hasattr(
-        eof_rotator, "model"
-    ), 'The attribute "model" should be populated after fitting.'
+        eof_rotator, "model_data"
+    ), 'The attribute "model_data" should be populated after fitting.'
     assert hasattr(
         eof_rotator, "data"
     ), 'The attribute "data" should be populated after fitting.'
-    assert isinstance(eof_rotator.model, EOF)
+    assert isinstance(eof_rotator.model_data, DataContainer)
     assert isinstance(eof_rotator.data, DataContainer)
 
 

--- a/tests/models/single/test_hilbert_eof_rotator.py
+++ b/tests/models/single/test_hilbert_eof_rotator.py
@@ -42,12 +42,12 @@ def test_fit(ceof_model):
     ceof_rotator.fit(ceof_model)
 
     assert hasattr(
-        ceof_rotator, "model"
-    ), 'The attribute "model" should be populated after fitting.'
+        ceof_rotator, "model_data"
+    ), 'The attribute "model_data" should be populated after fitting.'
     assert hasattr(
         ceof_rotator, "data"
     ), 'The attribute "data" should be populated after fitting.'
-    assert isinstance(ceof_rotator.model, HilbertEOF)
+    assert isinstance(ceof_rotator.model_data, DataContainer)
     assert isinstance(ceof_rotator.data, DataContainer)
 
 

--- a/xeofs/cross/mca_rotator.py
+++ b/xeofs/cross/mca_rotator.py
@@ -72,7 +72,6 @@ class MCARotator(CPCCARotator, MCA):
 
         # Define analysis-relevant meta data
         self.attrs.update({"model": "Rotated MCA"})
-        self.model = MCA()
 
 
 class ComplexMCARotator(ComplexCPCCARotator, ComplexMCA):
@@ -149,7 +148,6 @@ class ComplexMCARotator(ComplexCPCCARotator, ComplexMCA):
             compute=compute,
         )
         self.attrs.update({"model": "Rotated Complex MCA"})
-        self.model = ComplexMCA()
 
 
 class HilbertMCARotator(HilbertCPCCARotator, HilbertMCA):
@@ -226,4 +224,3 @@ class HilbertMCARotator(HilbertCPCCARotator, HilbertMCA):
             compute=compute,
         )
         self.attrs.update({"model": "Rotated Hilbert MCA"})
-        self.model = HilbertMCA()


### PR DESCRIPTION
This PR improves disk space efficiency when saving the `Rotator`. Previously, the entire model, including its `Preprocessor` and `Whitener`, was saved twice -- once for the original model and once for the Rotator. This resulted in redundant storage, particularly for the `Whitener`, which can be large due to its transformation matrix.

To address this, the PR no longer saves the entire original model. Instead, it creates a `DataContainer` for the original model and only copies the necessary `DataArrays` required by the Rotator, avoiding duplicate data.