### PR TITLE
fix: support new datatree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,11 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy>=1.24",
   "pandas>=2",
-  "xarray>=2023.04.0",
+  "xarray>=2024.10.0",
   "scikit-learn>=1.0.2",
   "tqdm>=4.64.0",
   "dask>=2023.0.1",
   "typing-extensions>=4.8.0",
-  "xarray-datatree>=0.0.12",
 ]
 
 [project.optional-dependencies]

--- a/xeofs/data_container/data_container.py
+++ b/xeofs/data_container/data_container.py
@@ -1,10 +1,6 @@
 import dask
+import xarray as xr
 from typing_extensions import Self
-
-try:
-    from xarray.core.datatree import DataTree
-except ImportError:
-    from datatree import DataTree
 
 from ..utils.data_types import DataArray
 
@@ -31,18 +27,18 @@ class DataContainer(dict):
                 f"Cannot find data '{__key}'. Please fit the model first by calling .fit()."
             )
 
-    def serialize(self) -> DataTree:
-        dt = DataTree(name="data")
+    def serialize(self) -> xr.DataTree:
+        dt = xr.DataTree(name="data")
         for key, data in self.items():
             if not data.name:
                 data.name = key
-            dt[key] = DataTree(data.to_dataset())
+            dt[key] = xr.DataTree(data.to_dataset())
             dt[key].attrs = {key: "_is_node", "allow_compute": self._allow_compute[key]}
 
         return dt
 
     @classmethod
-    def deserialize(cls, dt: DataTree) -> Self:
+    def deserialize(cls, dt: xr.DataTree) -> Self:
         container = cls()
         for key, node in dt.items():
             container[key] = node[key]

--- a/xeofs/preprocessing/preprocessor.py
+++ b/xeofs/preprocessing/preprocessor.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 from typing_extensions import Self
 
 from ..utils.data_types import (
@@ -22,11 +23,6 @@ from .sanitizer import Sanitizer
 from .scaler import Scaler
 from .stacker import Stacker
 from .transformer import Transformer
-
-try:
-    from xarray.core.datatree import DataTree
-except ImportError:
-    from datatree import DataTree
 
 
 def extract_new_dim_names(X: list[DimensionRenamer]) -> tuple[Dims, DimsList]:
@@ -369,7 +365,7 @@ class Preprocessor(Transformer):
         else:
             self.return_list = False
 
-    def serialize(self) -> DataTree:
+    def serialize(self) -> xr.DataTree:
         """Serialize the necessary attributes of the fitted pre-processor
         and all transformers to a Dataset."""
         # Serialize the preprocessor as the root node
@@ -381,9 +377,9 @@ class Preprocessor(Transformer):
         transformers = self.get_transformers()
 
         for name, transformer_obj in zip(names, transformers):
-            dt_transformer = DataTree()
+            dt_transformer = xr.DataTree()
             if isinstance(transformer_obj, GenericListTransformer):
-                dt_transformer["transformers"] = DataTree()
+                dt_transformer["transformers"] = xr.DataTree()
                 # Loop through list transformer objects and assign a dummy key
                 for i, transformer in enumerate(transformer_obj.transformers):
                     dt_transformer.transformers[str(i)] = transformer.serialize()
@@ -395,7 +391,7 @@ class Preprocessor(Transformer):
         return dt
 
     @classmethod
-    def deserialize(cls, dt: DataTree) -> Self:
+    def deserialize(cls, dt: xr.DataTree) -> Self:
         """Deserialize from a DataTree representation of the preprocessor
         and all attached Transformers."""
         # Create the parent preprocessor


### PR DESCRIPTION
[xarray==2024.10.0](https://docs.xarray.dev/en/stable/whats-new.html#v2024-10-0-oct-24th-2024) now has `DataTree` as public API, and the old prototype library has been [archived](https://github.com/xarray-contrib/datatree).

The modifications here drop support for the archived version and ensure everything works on the new version that's available in xarray. Only downside is we have to bump the lower bound on xarray support all the way up to present.